### PR TITLE
Name data structures better

### DIFF
--- a/vumi_http_retry/app.py
+++ b/vumi_http_retry/app.py
@@ -10,7 +10,7 @@ from confmodel import Config
 from confmodel.fields import ConfigText, ConfigInt
 from txredis.client import RedisClient
 
-from vumi_http_retry.retries import add_request
+from vumi_http_retry.retries import add_pending
 
 
 class VumiHttpRetryConfig(Config):
@@ -65,7 +65,7 @@ class VumiHttpRetryServer(object):
         # TODO rate limiting
         data = json.loads(req.content.read())
 
-        yield add_request(self.redis, self.config.redis_prefix, {
+        yield add_pending(self.redis, self.config.redis_prefix, {
             'owner_id': req.getHeader('x-owner-id'),
             'timestamp': time.time(),
             'request': data['request'],

--- a/vumi_http_retry/retries.py
+++ b/vumi_http_retry/retries.py
@@ -3,7 +3,7 @@ import json
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 
-def requests_key(prefix):
+def pending_key(prefix):
     return '.'.join((prefix, 'requests'))
 
 
@@ -16,7 +16,7 @@ def next_score(req):
     return req['timestamp'] + dt
 
 
-def add_request(redis, prefix, req):
+def add_pending(redis, prefix, req):
     req = {
         'owner_id': req['owner_id'],
         'timestamp': req['timestamp'],
@@ -25,12 +25,12 @@ def add_request(redis, prefix, req):
         'intervals': req['intervals']
     }
 
-    return redis.zadd(requests_key(prefix), next_score(req), json.dumps(req))
+    return redis.zadd(pending_key(prefix), next_score(req), json.dumps(req))
 
 
 @inlineCallbacks
-def peek_requests(redis, prefix, from_time, to_time):
-    k = requests_key(prefix)
+def peek_pending(redis, prefix, from_time, to_time):
+    k = pending_key(prefix)
 
     returnValue([
         json.loads(r)
@@ -38,9 +38,9 @@ def peek_requests(redis, prefix, from_time, to_time):
 
 
 @inlineCallbacks
-def pop_requests(redis, prefix, from_time, to_time):
-    k = requests_key(prefix)
-    requests = yield peek_requests(redis, prefix, from_time, to_time)
+def pop_pending(redis, prefix, from_time, to_time):
+    k = pending_key(prefix)
+    requests = yield peek_pending(redis, prefix, from_time, to_time)
     yield redis.zremrangebyscore(k, from_time, to_time)
     returnValue(requests)
 

--- a/vumi_http_retry/retries.py
+++ b/vumi_http_retry/retries.py
@@ -7,7 +7,7 @@ def pending_key(prefix):
     return '.'.join((prefix, 'requests'))
 
 
-def working_set_key(prefix):
+def ready_key(prefix):
     return '.'.join((prefix, 'working_set'))
 
 
@@ -46,14 +46,14 @@ def pop_pending(redis, prefix, from_time, to_time):
 
 
 @inlineCallbacks
-def add_to_working_set(redis, prefix, reqs):
+def add_ready(redis, prefix, reqs):
     reqs = [json.dumps(req) for req in reqs]
 
     if reqs:
-        yield redis.rpush(working_set_key(prefix), *reqs)
+        yield redis.rpush(ready_key(prefix), *reqs)
 
 
 @inlineCallbacks
-def pop_from_working_set(redis, prefix):
-    result = yield redis.lpop(working_set_key(prefix))
+def pop_ready(redis, prefix):
+    result = yield redis.lpop(ready_key(prefix))
     returnValue(json.loads(result) if result is not None else result)

--- a/vumi_http_retry/tests/test_app.py
+++ b/vumi_http_retry/tests/test_app.py
@@ -9,7 +9,7 @@ from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 
 from vumi_http_retry.app import VumiHttpRetryServer
-from vumi_http_retry.retries import requests_key
+from vumi_http_retry.retries import pending_key
 from vumi_http_retry.tests.redis import zitems, delete
 
 
@@ -56,7 +56,7 @@ class TestVumiHttpRetryServer(TestCase):
 
     @inlineCallbacks
     def test_requests(self):
-        k = requests_key('test')
+        k = pending_key('test')
 
         resp = yield self.post('/requests/', {
             'intervals': [30, 90],

--- a/vumi_http_retry/tests/test_retries.py
+++ b/vumi_http_retry/tests/test_retries.py
@@ -2,7 +2,7 @@ from twisted.trial.unittest import TestCase
 from twisted.internet.defer import inlineCallbacks
 
 from vumi_http_retry.retries import (
-    requests_key, working_set_key, add_request, peek_requests, pop_requests,
+    pending_key, working_set_key, add_pending, peek_pending, pop_pending,
     add_to_working_set, pop_from_working_set)
 
 from vumi_http_retry.tests.redis import create_client, zitems, lvalues, delete
@@ -19,11 +19,11 @@ class TestRetries(TestCase):
         self.redis.transport.loseConnection()
 
     @inlineCallbacks
-    def test_add_request(self):
-        k = requests_key('test')
+    def test_add_pending(self):
+        k = pending_key('test')
         self.assertEqual((yield zitems(self.redis, k)), [])
 
-        yield add_request(self.redis, 'test', {
+        yield add_pending(self.redis, 'test', {
             'owner_id': '1234',
             'timestamp': 10,
             'intervals': [50, 60],
@@ -40,7 +40,7 @@ class TestRetries(TestCase):
             }),
         ])
 
-        yield add_request(self.redis, 'test', {
+        yield add_pending(self.redis, 'test', {
             'owner_id': '1234',
             'timestamp': 5,
             'intervals': [20, 90],
@@ -65,11 +65,11 @@ class TestRetries(TestCase):
         ])
 
     @inlineCallbacks
-    def test_add_request_next_retry(self):
-        k = requests_key('test')
+    def test_add_pending_next_retry(self):
+        k = pending_key('test')
         self.assertEqual((yield zitems(self.redis, k)), [])
 
-        yield add_request(self.redis, 'test', {
+        yield add_pending(self.redis, 'test', {
             'owner_id': '1234',
             'timestamp': 10,
             'attempts': 1,
@@ -87,7 +87,7 @@ class TestRetries(TestCase):
             }),
         ])
 
-        yield add_request(self.redis, 'test', {
+        yield add_pending(self.redis, 'test', {
             'owner_id': '1234',
             'timestamp': 5,
             'attempts': 2,
@@ -113,11 +113,11 @@ class TestRetries(TestCase):
         ])
 
     @inlineCallbacks
-    def test_peek_requests(self):
-        k = requests_key('test')
+    def test_peek_pending(self):
+        k = pending_key('test')
 
         for t in range(5, 20, 5):
-            yield add_request(self.redis, 'test', {
+            yield add_pending(self.redis, 'test', {
                 'owner_id': '1234',
                 'timestamp': t,
                 'attempts': 0,
@@ -128,25 +128,25 @@ class TestRetries(TestCase):
         original_items = yield zitems(self.redis, k)
         original_values = [v for t, v in original_items]
 
-        result = yield peek_requests(self.redis, 'test', 0, 10 + 7)
+        result = yield peek_pending(self.redis, 'test', 0, 10 + 7)
         self.assertEqual(result, original_values[:1])
         self.assertEqual((yield zitems(self.redis, k)), original_items)
 
-        result = yield peek_requests(self.redis, 'test', 0, 10 + 13)
+        result = yield peek_pending(self.redis, 'test', 0, 10 + 13)
         self.assertEqual(result, original_values[:2])
         self.assertEqual((yield zitems(self.redis, k)), original_items)
 
-        result = yield peek_requests(self.redis, 'test', 22, 10 + 17)
+        result = yield peek_pending(self.redis, 'test', 22, 10 + 17)
 
         self.assertEqual(result, original_values[2:])
         self.assertEqual((yield zitems(self.redis, k)), original_items)
 
     @inlineCallbacks
-    def test_pop_requests(self):
-        k = requests_key('test')
+    def test_pop_pending(self):
+        k = pending_key('test')
 
         for t in range(5, 35, 5):
-            yield add_request(self.redis, 'test', {
+            yield add_pending(self.redis, 'test', {
                 'owner_id': '1234',
                 'timestamp': t,
                 'attempts': 0,
@@ -157,11 +157,11 @@ class TestRetries(TestCase):
         original_items = yield zitems(self.redis, k)
         original_values = [v for t, v in original_items]
 
-        result = yield pop_requests(self.redis, 'test', 0, 10 + 13)
+        result = yield pop_pending(self.redis, 'test', 0, 10 + 13)
         self.assertEqual(result, original_values[:2])
         self.assertEqual((yield zitems(self.redis, k)), original_items[2:])
 
-        result = yield pop_requests(self.redis, 'test', 10 + 18, 10 + 27)
+        result = yield pop_pending(self.redis, 'test', 10 + 18, 10 + 27)
         self.assertEqual(result, original_values[3:5])
 
         self.assertEqual(

--- a/vumi_http_retry/tests/test_retries.py
+++ b/vumi_http_retry/tests/test_retries.py
@@ -125,21 +125,21 @@ class TestRetries(TestCase):
                 'request': {'foo': t}
             })
 
-        original_items = yield zitems(self.redis, k)
-        original_values = [v for t, v in original_items]
+        pending = yield zitems(self.redis, k)
+        pending_reqs = [r for t, r in pending]
 
         result = yield peek_pending(self.redis, 'test', 0, 10 + 7)
-        self.assertEqual(result, original_values[:1])
-        self.assertEqual((yield zitems(self.redis, k)), original_items)
+        self.assertEqual(result, pending_reqs[:1])
+        self.assertEqual((yield zitems(self.redis, k)), pending)
 
         result = yield peek_pending(self.redis, 'test', 0, 10 + 13)
-        self.assertEqual(result, original_values[:2])
-        self.assertEqual((yield zitems(self.redis, k)), original_items)
+        self.assertEqual(result, pending_reqs[:2])
+        self.assertEqual((yield zitems(self.redis, k)), pending)
 
         result = yield peek_pending(self.redis, 'test', 22, 10 + 17)
 
-        self.assertEqual(result, original_values[2:])
-        self.assertEqual((yield zitems(self.redis, k)), original_items)
+        self.assertEqual(result, pending_reqs[2:])
+        self.assertEqual((yield zitems(self.redis, k)), pending)
 
     @inlineCallbacks
     def test_pop_pending(self):
@@ -154,19 +154,19 @@ class TestRetries(TestCase):
                 'request': {'foo': t}
             })
 
-        original_items = yield zitems(self.redis, k)
-        original_values = [v for t, v in original_items]
+        pending = yield zitems(self.redis, k)
+        pending_reqs = [r for t, r in pending]
 
         result = yield pop_pending(self.redis, 'test', 0, 10 + 13)
-        self.assertEqual(result, original_values[:2])
-        self.assertEqual((yield zitems(self.redis, k)), original_items[2:])
+        self.assertEqual(result, pending_reqs[:2])
+        self.assertEqual((yield zitems(self.redis, k)), pending[2:])
 
         result = yield pop_pending(self.redis, 'test', 10 + 18, 10 + 27)
-        self.assertEqual(result, original_values[3:5])
+        self.assertEqual(result, pending_reqs[3:5])
 
         self.assertEqual(
             (yield zitems(self.redis, k)),
-            original_items[2:3] + original_items[5:])
+            pending[2:3] + pending[5:])
 
     @inlineCallbacks
     def test_add_ready(self):


### PR DESCRIPTION
Conceptually, we have a set of retries that are pending but not yet due, and a 'working set' of due retries, but lack proper names for both, which is making working with and testing the functions that operate on them difficult. The plan is to name the first set the 'pending' and the latter the 'ready' set, and rename the functions operating on them better.
