### PR TITLE
More graceful stopping for maintainer worker

### DIFF
--- a/vumi_http_retry/workers/maintainer/tests/test_worker.py
+++ b/vumi_http_retry/workers/maintainer/tests/test_worker.py
@@ -45,7 +45,7 @@ class TestRetryMaintainerWorker(TestCase):
             'frequency': 20,
         })
 
-        worker.stop_maintain_loop()
+        worker.stop()
 
         for t in range(5, 25, 5):
             yield add_pending(worker.redis, 'test', {
@@ -88,7 +88,7 @@ class TestRetryMaintainerWorker(TestCase):
         self.assertEqual((yield zitems(worker.redis, k_p)), [])
 
     @inlineCallbacks
-    def test_maintain_loop(self):
+    def test_loop(self):
         k_p = pending_key('test')
         k_r = ready_key('test')
 
@@ -143,6 +143,6 @@ class TestRetryMaintainerWorker(TestCase):
 
         self.assertEqual(worker.maintains, [])
 
-        worker.stop_maintain_loop()
+        worker.stop()
         worker.clock.advance(5)
         self.assertEqual(worker.maintains, [])

--- a/vumi_http_retry/workers/maintainer/tests/test_worker.py
+++ b/vumi_http_retry/workers/maintainer/tests/test_worker.py
@@ -1,6 +1,7 @@
 from twisted.internet.task import Clock
 from twisted.trial.unittest import TestCase
-from twisted.internet.defer import inlineCallbacks, returnValue, succeed
+from twisted.internet.defer import (
+    Deferred, inlineCallbacks, returnValue, succeed)
 
 from vumi_http_retry.workers.maintainer.worker import RetryMaintainerWorker
 from vumi_http_retry.retries import pending_key, ready_key, add_pending
@@ -146,3 +147,19 @@ class TestRetryMaintainerWorker(TestCase):
         worker.stop()
         worker.clock.advance(5)
         self.assertEqual(worker.maintains, [])
+
+    @inlineCallbacks
+    def test_stopping(self):
+        """
+        If a stop happens in the middle of a maintain, it should finish the
+        maintain before stopping
+        """
+        worker = yield self.mk_worker({
+            'redis_prefix': 'test',
+            'frequency': 5,
+        })
+
+        worker.stop()
+        self.assertTrue(worker.stopping)
+        yield worker.maintains.pop()
+        self.assertTrue(worker.stopped)

--- a/vumi_http_retry/workers/maintainer/worker.py
+++ b/vumi_http_retry/workers/maintainer/worker.py
@@ -42,14 +42,14 @@ class RetryMaintainerWorker(BaseWorker):
             self.config.redis_host,
             self.config.redis_port)
 
-        self.maintain_loop = LoopingCall(self.maintain)
-        self.maintain_loop.clock = self.clock
+        self.loop = LoopingCall(self.maintain)
+        self.loop.clock = self.clock
 
-        self.start_maintain_loop()
+        self.start()
 
     def teardown(self):
         self.redis.transport.loseConnection()
-        self.stop_maintain_loop()
+        self.stop()
 
     @inlineCallbacks
     def maintain(self):
@@ -57,9 +57,9 @@ class RetryMaintainerWorker(BaseWorker):
         reqs = yield pop_pending(self.redis, prefix, 0, self.clock.seconds())
         yield add_ready(self.redis, prefix, reqs)
 
-    def start_maintain_loop(self):
-        self.maintain_loop.start(self.config.frequency, now=True)
+    def start(self):
+        self.loop.start(self.config.frequency, now=True)
 
-    def stop_maintain_loop(self):
-        if self.maintain_loop.running:
-            self.maintain_loop.stop()
+    def stop(self):
+        if self.loop.running:
+            self.loop.stop()


### PR DESCRIPTION
It would be better to allow the current looping call to finish its work before stopping.
