### PR TITLE
Add total request limiting

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -77,7 +77,9 @@ API Methods
 
    :resheader Content-Type: ``application/json``.
 
-   *Note*: A maximum of ``10000`` request retries are allowed per owner per 30 minutes. If this is exceeded, the api will send a ``429`` error response. See :ref:`example below <too-many-requests-response-example>`.
+   *Note*: A maximum of ``10000`` unfinished request retries are allowed per
+   owner. If this is exceeded, the api will send a ``429`` error response. See
+   :ref:`example below <too-many-requests-response-example>`.
 
    **Example request**:
 
@@ -121,6 +123,6 @@ API Methods
        {
            "errors": [{
                "type": "too_many_requests",
-               "message": "Only 10000 requests are allowed per owner per 30 minutes"
+               "message": "Only 10000 unfinished requests are allowed per owner"
            }]
        }

--- a/vumi_http_retry/retries.py
+++ b/vumi_http_retry/retries.py
@@ -13,6 +13,28 @@ def ready_key(prefix):
     return '.'.join((prefix, 'working_set'))
 
 
+def req_count_key(prefix, owner_id):
+    return '.'.join((prefix, 'request_count', owner_id))
+
+
+def inc_req_count(redis, prefix, owner_id):
+    return redis.incr(req_count_key(prefix, owner_id))
+
+
+def dec_req_count(redis, prefix, owner_id):
+    return redis.decr(req_count_key(prefix, owner_id))
+
+
+def set_req_count(redis, prefix, owner_id, value):
+    return redis.set(req_count_key(prefix, owner_id), value)
+
+
+@inlineCallbacks
+def get_req_count(redis, prefix, owner_id):
+    v = yield redis.get(req_count_key(prefix, owner_id))
+    returnValue(int(v) if v is not None else 0)
+
+
 def next_score(req):
     dt = req['intervals'][req['attempts']]
     return req['timestamp'] + dt

--- a/vumi_http_retry/workers/api/tests/test_worker.py
+++ b/vumi_http_retry/workers/api/tests/test_worker.py
@@ -104,7 +104,7 @@ class TestRetryApiWorker(TestCase):
             }
         }, headers={'X-Owner-ID': '1234'})
 
-        self.assertEqual(resp.code, 419)
+        self.assertEqual(resp.code, 429)
         self.assertEqual(json.loads((yield resp.content())), {
             'errors': [{
                 'type': 'too_many_requests',

--- a/vumi_http_retry/workers/api/worker.py
+++ b/vumi_http_retry/workers/api/worker.py
@@ -99,7 +99,7 @@ class RetryApiWorker(BaseWorker):
                     'message': "Only 10000 unfinished requests are "
                                "allowed per owner"
                 }]
-            }, code=419))
+            }, code=429))
         else:
             yield add_pending(self.redis, self.prefix, {
                 'owner_id': req.getHeader('x-owner-id'),


### PR DESCRIPTION
The plan is to increment/decrement a counter per owner id when a request is added/finished, and check the counter when adding a new request via the api.
