### PR TITLE
Add errbacks for looping calls

### DIFF
--- a/vumi_http_retry/workers/maintainer/tests/test_worker.py
+++ b/vumi_http_retry/workers/maintainer/tests/test_worker.py
@@ -26,6 +26,19 @@ class TestRetryMaintainerWorker(TestCase):
         yield delete(worker.redis, 'test.*')
         yield worker.teardown()
 
+    def patch_on_error(self):
+        errors = []
+
+        def on_error(f):
+            errors.append(f.value)
+
+        fn = staticmethod(on_error)
+        self.patch(ToyRetryMaintainerWorker, 'on_error', fn)
+        return errors
+
+    def patch_maintain(self, fn):
+        self.patch(ToyRetryMaintainerWorker, 'maintain', fn)
+
     @inlineCallbacks
     def mk_worker(self, config):
         config['redis_pefix'] = 'test'
@@ -147,6 +160,25 @@ class TestRetryMaintainerWorker(TestCase):
         worker.stop()
         worker.clock.advance(5)
         self.assertEqual(worker.maintains, [])
+
+    @inlineCallbacks
+    def test_loop_error(self):
+        e = Exception(':/')
+
+        def bad_maintain():
+            raise e
+
+        errors = self.patch_on_error()
+        self.patch_maintain(staticmethod(bad_maintain))
+        worker = yield self.mk_worker({'frequency': 5})
+
+        self.assertEqual(errors, [e])
+
+        worker.clock.advance(5)
+        self.assertEqual(errors, [e])
+
+        worker.clock.advance(5)
+        self.assertEqual(errors, [e])
 
     @inlineCallbacks
     def test_stopping(self):

--- a/vumi_http_retry/workers/maintainer/worker.py
+++ b/vumi_http_retry/workers/maintainer/worker.py
@@ -78,9 +78,13 @@ class RetryMaintainerWorker(BaseWorker):
             to_time=self.clock.seconds(),
             chunk_size=self.config.pop_chunk_size)
 
+    def on_error(self, err):
+        log.err(err)
+
     def start(self):
-        self.loop_d = self.loop.start(self.config.frequency, now=True)
         self.state = 'started'
+        self.loop_d = self.loop.start(self.config.frequency, now=True)
+        self.loop_d.addErrback(self.on_error)
 
     @inlineCallbacks
     def stop(self):

--- a/vumi_http_retry/workers/sender/worker.py
+++ b/vumi_http_retry/workers/sender/worker.py
@@ -1,3 +1,4 @@
+from twisted.python import log
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from twisted.internet.protocol import ClientCreator
@@ -99,9 +100,13 @@ class RetrySenderWorker(BaseWorker):
 
             yield self.retry(req)
 
+    def on_error(self, err):
+        log.err(err)
+
     def start(self):
         self.state = 'started'
         self.loop_d = self.loop.start(self.config.frequency, now=True)
+        self.loop_d.addErrback(self.on_error)
 
     @inlineCallbacks
     def stop(self):


### PR DESCRIPTION
At the moment, we only see errors from looping calls when tearing down their worker.
