### PR TITLE
Allow the redis db number to be configured

### DIFF
--- a/vumi_http_retry/workers/maintainer/tests/test_worker.py
+++ b/vumi_http_retry/workers/maintainer/tests/test_worker.py
@@ -1,7 +1,6 @@
 from twisted.internet.task import Clock
 from twisted.trial.unittest import TestCase
-from twisted.internet.defer import (
-    Deferred, inlineCallbacks, returnValue, succeed)
+from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi_http_retry.workers.maintainer.worker import RetryMaintainerWorker
 from vumi_http_retry.retries import pending_key, ready_key, add_pending
@@ -163,3 +162,14 @@ class TestRetryMaintainerWorker(TestCase):
         self.assertTrue(worker.stopping)
         yield worker.maintains.pop()
         self.assertTrue(worker.stopped)
+
+    @inlineCallbacks
+    def test_config_redis_db(self):
+        worker = yield self.mk_worker({
+            'redis_prefix': 'test',
+            'redis_db': 1
+        })
+
+        yield worker.redis.set('test.foo', 'bar')
+        yield worker.redis.select(1)
+        self.assertEqual((yield worker.redis.get('test.foo')), 'bar')

--- a/vumi_http_retry/workers/maintainer/worker.py
+++ b/vumi_http_retry/workers/maintainer/worker.py
@@ -27,6 +27,9 @@ class RetryMaintainerConfig(Config):
     redis_port = ConfigInt(
         "Redis client port",
         default=6379)
+    redis_db = ConfigInt(
+        "Redis database number",
+        default=0)
 
 
 class RetryMaintainerWorker(BaseWorker):
@@ -51,7 +54,8 @@ class RetryMaintainerWorker(BaseWorker):
 
         self.clock = clock
 
-        redisCreator = ClientCreator(reactor, RedisClient)
+        redisCreator = ClientCreator(
+            reactor, RedisClient, db=self.config.redis_db)
 
         self.redis = yield redisCreator.connectTCP(
             self.config.redis_host,

--- a/vumi_http_retry/workers/sender/tests/test_worker.py
+++ b/vumi_http_retry/workers/sender/tests/test_worker.py
@@ -325,3 +325,14 @@ class TestRetrySenderWorker(TestCase):
         self.assertEqual(req, popped_req)
         self.assertEqual(pops, [])
         self.assertTrue(worker.stopped)
+
+    @inlineCallbacks
+    def test_config_redis_db(self):
+        worker = yield self.mk_worker({
+            'redis_prefix': 'test',
+            'redis_db': 1
+        })
+
+        yield worker.redis.set('test.foo', 'bar')
+        yield worker.redis.select(1)
+        self.assertEqual((yield worker.redis.get('test.foo')), 'bar')

--- a/vumi_http_retry/workers/sender/worker.py
+++ b/vumi_http_retry/workers/sender/worker.py
@@ -25,6 +25,9 @@ class RetrySenderConfig(Config):
     redis_port = ConfigInt(
         "Redis client port",
         default=6379)
+    redis_db = ConfigInt(
+        "Redis database number",
+        default=0)
     overrides = ConfigDict(
         "Options to override for each request",
         default={})
@@ -54,7 +57,8 @@ class RetrySenderWorker(BaseWorker):
 
         self.clock = clock
 
-        redisCreator = ClientCreator(reactor, RedisClient)
+        redisCreator = ClientCreator(
+            reactor, RedisClient, db=self.config.redis_db)
 
         self.redis = yield redisCreator.connectTCP(
             self.config.redis_host,


### PR DESCRIPTION
At the moment, we don't tell txredis which dbnum to use, so it uses `0`.
