### PR TITLE
Fix retrying

### DIFF
--- a/vumi_http_retry/retries.py
+++ b/vumi_http_retry/retries.py
@@ -102,10 +102,12 @@ def retry(req, **overrides):
     d = req['request']
 
     opts = {
-        'method': d['method'],
-        'url': d['url'],
-        'data': d.get('body'),
-        'headers': d.get('headers')
+        'method': encode(d['method']),
+        'url': encode(d['url']),
+        'data': encode(d.get('body')),
+        'headers': dict([
+            (encode(k), [encode(v) for v in values])
+            for k, values in d.get('headers', {}).iteritems()]),
     }
 
     opts.update(overrides)
@@ -118,3 +120,7 @@ def should_retry(resp):
 
 def can_reattempt(req):
     return req['attempts'] < len(req['intervals'])
+
+
+def encode(v, encoding='utf-8'):
+    return v.encode(encoding) if v is not None else v

--- a/vumi_http_retry/retries.py
+++ b/vumi_http_retry/retries.py
@@ -104,7 +104,7 @@ def retry(req, **overrides):
     opts = {
         'method': d['method'],
         'url': d['url'],
-        'data': d.get('data'),
+        'data': d.get('body'),
         'headers': d.get('headers')
     }
 

--- a/vumi_http_retry/tests/test_retries.py
+++ b/vumi_http_retry/tests/test_retries.py
@@ -418,7 +418,7 @@ class TestRetries(TestCase):
             'request': {
                 'url': "%s/foo" % (srv.url,),
                 'method': 'POST',
-                'data': 'hi'
+                'body': 'hi'
             }
         }, persistent=False)
 

--- a/vumi_http_retry/tests/test_retries.py
+++ b/vumi_http_retry/tests/test_retries.py
@@ -485,6 +485,41 @@ class TestRetries(TestCase):
         self.assertEqual(req['attempts'], 3)
 
     @inlineCallbacks
+    def test_retry_unicode(self):
+        srv = yield ToyServer.from_test(self)
+        reqs = []
+
+        @srv.app.route('/')
+        def route(req):
+            reqs.append({
+                'method': req.method,
+                'body': req.content.read(),
+                'headers': {
+                    'X-Bar': req.requestHeaders.getRawHeaders('X-Bar'),
+                }
+            })
+
+        yield retry({
+            'owner_id': '1234',
+            'timestamp': 5,
+            'attempts': 0,
+            'intervals': [10, 20, 30],
+            'request': {
+                'url': u"%s" % (srv.url,),
+                'method': u'POST',
+                'body': u'foo',
+                'headers': {u'X-Bar': [u'baz', u'quux']}
+            }
+        }, persistent=False)
+
+        [req] = reqs
+        self.assertEqual(req, {
+            'method': 'POST',
+            'body': 'foo',
+            'headers': {'X-Bar': ['baz', 'quux']}
+        })
+
+    @inlineCallbacks
     def test_should_retry(self):
         srv = yield ToyServer.from_test(self)
 


### PR DESCRIPTION
At the moment, treq is failing at making the requests because its being given unicode values for the request method, url, body and header values. It also appears to be failing silently.
