### PR TITLE
Change sender worker to send a set of requests concurrently

### DIFF
--- a/vumi_http_retry/tests/tests/test_utils.py
+++ b/vumi_http_retry/tests/tests/test_utils.py
@@ -58,7 +58,7 @@ class TestManualReadable(TestCase):
         yield r.err(e)
         self.assertEqual(errs, [e])
 
-    def test_err_empy_reading(self):
+    def test_err_empty_reading(self):
         r = ManualReadable([23])
         self.assertRaises(Exception, r.err, Exception())
 
@@ -118,6 +118,6 @@ class TestManualWritable(TestCase):
         yield w.err(e)
         self.assertEqual(errs, [e])
 
-    def test_err_empy_writing(self):
+    def test_err_empty_writing(self):
         w = ManualWritable()
         self.assertRaises(Exception, w.err)

--- a/vumi_http_retry/tests/tests/test_utils.py
+++ b/vumi_http_retry/tests/tests/test_utils.py
@@ -1,7 +1,66 @@
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import inlineCallbacks
 
-from vumi_http_retry.tests.utils import ManualWritable
+from vumi_http_retry.tests.utils import ManualReadable, ManualWritable
+
+
+class TestManualReadable(TestCase):
+    @inlineCallbacks
+    def test_reading(self):
+        r = ManualReadable([1, 2, 3, 4])
+        self.assertEqual(r.unread, [1, 2, 3, 4])
+        self.assertEqual(r.reading, [])
+
+        d1 = r.read()
+        self.assertEqual(r.unread, [2, 3, 4])
+        self.assertEqual(r.reading, [1])
+
+        d2 = r.read()
+        self.assertEqual(r.unread, [3, 4])
+        self.assertEqual(r.reading, [1, 2])
+
+        self.assertEqual(d1, r.next())
+        self.assertEqual((yield d1), 1)
+        self.assertEqual(r.unread, [3, 4])
+        self.assertEqual(r.reading, [2])
+
+        self.assertEqual(d2, r.next())
+        self.assertEqual((yield d2), 2)
+        self.assertEqual(r.unread, [3, 4])
+        self.assertEqual(r.reading, [])
+
+        d = r.read()
+        self.assertEqual(r.unread, [4])
+        self.assertEqual(r.reading, [3])
+        self.assertEqual(d, r.next())
+        self.assertEqual((yield d), 3)
+
+        d = r.read()
+        self.assertEqual(r.unread, [])
+        self.assertEqual(r.reading, [4])
+        self.assertEqual(d, r.next())
+        self.assertEqual((yield d), 4)
+
+        self.assertEqual((yield r.read()), None)
+        self.assertEqual((yield r.read()), None)
+
+    def test_next_empty_reading(self):
+        r = ManualReadable([23])
+        self.assertRaises(Exception, r.next)
+
+    @inlineCallbacks
+    def test_err(self):
+        r = ManualReadable([23])
+        e = Exception()
+        errs = []
+        d = r.read()
+        d.addErrback(lambda f: errs.append(f.value))
+        yield r.err(e)
+        self.assertEqual(errs, [e])
+
+    def test_err_empy_reading(self):
+        r = ManualReadable([23])
+        self.assertRaises(Exception, r.err, Exception())
 
 
 class TestManualWritable(TestCase):

--- a/vumi_http_retry/tests/utils.py
+++ b/vumi_http_retry/tests/utils.py
@@ -28,6 +28,42 @@ class ToyServer(object):
         returnValue(server)
 
 
+class ManualReadable(object):
+    def __init__(self, values=None):
+        self.unread = values if values is not None else []
+        self.reading = []
+        self.deferreds = []
+
+    def next(self):
+        if not self.reading:
+            raise Exception("Nothing in `reading`")
+
+        d = self.deferreds.pop(0)
+        d.callback(self.reading.pop(0))
+        return d
+
+    def err(self, e):
+        if not self.reading:
+            raise Exception("Nothing in `reading`")
+
+        self.reading.pop(0)
+        d = self.deferreds.pop(0)
+        d.errback(e)
+        return d
+
+    def read(self):
+        d = Deferred()
+
+        if not self.unread:
+            d.callback(None)
+        else:
+            v = self.unread.pop(0)
+            self.reading.append(v)
+            self.deferreds.append(d)
+
+        return d
+
+
 class ManualWritable(object):
     def __init__(self):
         self.written = []

--- a/vumi_http_retry/workers/sender/tests/test_worker.py
+++ b/vumi_http_retry/workers/sender/tests/test_worker.py
@@ -337,7 +337,7 @@ class TestRetrySenderWorker(TestCase):
         self.patch(RetrySenderWorker, 'next_req', staticmethod(r.read))
         self.patch(RetrySenderWorker, 'retry', staticmethod(w.write))
 
-        worker = yield self.mk_worker({
+        yield self.mk_worker({
             'frequency': 5,
             'concurrency_limit': 2,
         })
@@ -429,7 +429,7 @@ class TestRetrySenderWorker(TestCase):
         self.patch(RetrySenderWorker, 'next_req', staticmethod(r.read))
         self.patch(RetrySenderWorker, 'retry', staticmethod(w.write))
 
-        worker = yield self.mk_worker({
+        yield self.mk_worker({
             'frequency': 5,
             'concurrency_limit': 2,
         })

--- a/vumi_http_retry/workers/sender/tests/test_worker.py
+++ b/vumi_http_retry/workers/sender/tests/test_worker.py
@@ -1,4 +1,3 @@
-from twisted.python.failure import Failure
 from twisted.internet.task import Clock
 from twisted.trial.unittest import TestCase
 from twisted.internet.defer import (
@@ -8,7 +7,8 @@ from vumi_http_retry.workers.sender.worker import RetrySenderWorker
 from vumi_http_retry.retries import (
     set_req_count, get_req_count, pending_key, ready_key, add_ready)
 from vumi_http_retry.tests.redis import zitems, lvalues, delete
-from vumi_http_retry.tests.utils import ToyServer
+from vumi_http_retry.tests.utils import (
+    ToyServer, ManualReadable, ManualWritable)
 
 
 class TestRetrySenderWorker(TestCase):
@@ -329,6 +329,94 @@ class TestRetrySenderWorker(TestCase):
 
         worker.clock.advance(5)
         self.assertEqual(errors, [e])
+
+    @inlineCallbacks
+    def test_loop_concurrency_limit(self):
+        r = ManualReadable([1, 2, 3, 4, 5])
+        w = ManualWritable()
+        self.patch(RetrySenderWorker, 'next_req', staticmethod(r.read))
+        self.patch(RetrySenderWorker, 'retry', staticmethod(w.write))
+
+        worker = yield self.mk_worker({
+            'frequency': 5,
+            'concurrency_limit': 2,
+        })
+
+        # We haven't yet started any retries
+        self.assertEqual(r.unread, [2, 3, 4, 5])
+        self.assertEqual(r.reading, [1])
+        self.assertEqual(w.writing, [])
+        self.assertEqual(w.written, [])
+
+        # We've started retrying request 1 and still have space
+        yield r.next()
+        self.assertEqual(r.unread, [3, 4, 5])
+        self.assertEqual(r.reading, [2])
+        self.assertEqual(w.writing, [1])
+        self.assertEqual(w.written, [])
+
+        # We've started retrying request 2 and are at capacity
+        yield r.next()
+        self.assertEqual(r.unread, [4, 5])
+        self.assertEqual(r.reading, [3])
+        self.assertEqual(w.writing, [1, 2])
+        self.assertEqual(w.written, [])
+
+        # We've read request 3 from redis but haven't retried it yet, since we
+        # are waiting for request 1 and 2 to complete
+        yield r.next()
+        self.assertEqual(r.unread, [4, 5])
+        self.assertEqual(r.reading, [])
+        self.assertEqual(w.writing, [1, 2])
+        self.assertEqual(w.written, [])
+
+        # Request 1 has completed, so we have space to start retrying
+        # request 3 and ask redis for request 4.
+        yield w.next()
+        self.assertEqual(r.unread, [5])
+        self.assertEqual(r.reading, [4])
+        self.assertEqual(w.writing, [2, 3])
+        self.assertEqual(w.written, [1])
+
+        # We've read request 4 from redis but haven't retried it yet, since we
+        # are waiting for request 2 and 3 to complete
+        yield r.next()
+        self.assertEqual(r.unread, [5])
+        self.assertEqual(r.reading, [])
+        self.assertEqual(w.writing, [2, 3])
+        self.assertEqual(w.written, [1])
+
+        # Request 2 has completed, so we have space to start retrying
+        # request 3 and ask redis for request 5.
+        yield w.next()
+        self.assertEqual(r.unread, [])
+        self.assertEqual(r.reading, [5])
+        self.assertEqual(w.writing, [3, 4])
+        self.assertEqual(w.written, [1, 2])
+
+        # Request 3 and 4 complete while we are waiting for request 5
+        # from redis
+        yield w.next()
+        yield w.next()
+        self.assertEqual(r.unread, [])
+        self.assertEqual(r.reading, [5])
+        self.assertEqual(w.writing, [])
+        self.assertEqual(w.written, [1, 2, 3, 4])
+
+        # We've read request 5 from redis and started retrying it
+        yield r.next()
+        self.assertEqual(r.unread, [])
+        self.assertEqual(r.reading, [])
+        self.assertEqual(w.writing, [5])
+        self.assertEqual(w.written, [1, 2, 3, 4])
+
+        # We've retried request 5. Redis says we have nothing more to read, so
+        # we are done.
+        yield w.next()
+        self.assertEqual(r.unread, [])
+        self.assertEqual(r.reading, [])
+        self.assertEqual(w.writing, [])
+        self.assertEqual(w.written, [1, 2, 3, 4, 5])
 
     @inlineCallbacks
     def test_stop_after_pop_non_empty(self):

--- a/vumi_http_retry/workers/sender/worker.py
+++ b/vumi_http_retry/workers/sender/worker.py
@@ -9,6 +9,7 @@ from confmodel import Config
 from confmodel.fields import ConfigText, ConfigInt, ConfigDict
 
 from vumi_http_retry.worker import BaseWorker
+from vumi_http_retry.limiter import TaskLimiter
 from vumi_http_retry.retries import (
     dec_req_count, pop_ready, retry, should_retry, can_reattempt, add_pending)
 
@@ -17,6 +18,9 @@ class RetrySenderConfig(Config):
     frequency = ConfigInt(
         "How often the ready set should be polled",
         default=60)
+    concurrency_limit = ConfigInt(
+        "Number of requests that are allowed to run concurrently",
+        default=100)
     redis_prefix = ConfigText(
         "Prefix for redis keys",
         default='vumi_http_retry')
@@ -93,16 +97,22 @@ class RetrySenderWorker(BaseWorker):
 
     @inlineCallbacks
     def poll(self):
+        limiter = TaskLimiter(
+            self.config.concurrency_limit,
+            errback=self.on_error)
+
         while True:
             if self.stopping:
                 break
 
             req = yield self.next_req()
 
-            if not req:
+            if req is None:
                 break
 
-            yield self.retry(req)
+            yield limiter.add(self.retry, req)
+
+        yield limiter.done()
 
     def on_error(self, err):
         log.err(err)

--- a/vumi_http_retry/workers/sender/worker.py
+++ b/vumi_http_retry/workers/sender/worker.py
@@ -116,6 +116,7 @@ class RetrySenderWorker(BaseWorker):
 
     def on_error(self, err):
         log.err(err)
+        reactor.stop()
 
     def start(self):
         self.state = 'started'


### PR DESCRIPTION
Since the kind of requests that will be given to the retry api are often going to be requests that timed out (and are likely to time out again), it doesn't make sense to block on each request. It would be more useful to have a set of requests running concurrently.
