### PR TITLE
Stop services on looping call errors

### DIFF
--- a/vumi_http_retry/tests/utils.py
+++ b/vumi_http_retry/tests/utils.py
@@ -93,3 +93,11 @@ class ManualWritable(object):
         d = Deferred()
         self.deferreds.append(d)
         return d
+
+
+class Counter(object):
+    def __init__(self):
+        self.value = 0
+
+    def inc(self):
+        self.value = self.value + 1

--- a/vumi_http_retry/workers/maintainer/tests/test_worker.py
+++ b/vumi_http_retry/workers/maintainer/tests/test_worker.py
@@ -5,6 +5,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from vumi_http_retry.workers.maintainer.worker import RetryMaintainerWorker
 from vumi_http_retry.retries import pending_key, ready_key, add_pending
 from vumi_http_retry.tests.redis import zitems, lvalues, delete
+from vumi_http_retry.tests.utils import Counter
 
 
 class ToyRetryMaintainerWorker(RetryMaintainerWorker):
@@ -34,6 +35,11 @@ class TestRetryMaintainerWorker(TestCase):
         fn = staticmethod(on_error)
         self.patch(ToyRetryMaintainerWorker, 'on_error', fn)
         return errors
+
+    def patch_reactor_stop(self):
+        c = Counter()
+        self.patch(ToyRetryMaintainerWorker, 'stop_reactor', c.inc)
+        return c
 
     def patch_maintain(self, fn):
         self.patch(ToyRetryMaintainerWorker, 'maintain', fn)
@@ -205,3 +211,18 @@ class TestRetryMaintainerWorker(TestCase):
         yield worker.redis.set('test.foo', 'bar')
         yield worker.redis.select(1)
         self.assertEqual((yield worker.redis.get('test.foo')), 'bar')
+
+    @inlineCallbacks
+    def test_on_error(self):
+        stops = self.patch_reactor_stop()
+        worker = yield self.mk_worker()
+        yield worker.stop()
+
+        self.flushLoggedErrors()
+        self.assertEqual(stops.value, 0)
+
+        err = Exception()
+        worker.on_error(err)
+
+        self.assertEqual([e.value for e in self.flushLoggedErrors()], [err])
+        self.assertEqual(stops.value, 1)

--- a/vumi_http_retry/workers/maintainer/tests/test_worker.py
+++ b/vumi_http_retry/workers/maintainer/tests/test_worker.py
@@ -45,7 +45,10 @@ class TestRetryMaintainerWorker(TestCase):
         self.patch(ToyRetryMaintainerWorker, 'maintain', fn)
 
     @inlineCallbacks
-    def mk_worker(self, config):
+    def mk_worker(self, config=None):
+        if config is None:
+            config = {}
+
         config['redis_pefix'] = 'test'
         worker = ToyRetryMaintainerWorker(config)
 

--- a/vumi_http_retry/workers/maintainer/tests/test_worker.py
+++ b/vumi_http_retry/workers/maintainer/tests/test_worker.py
@@ -221,7 +221,7 @@ class TestRetryMaintainerWorker(TestCase):
         worker = yield self.mk_worker()
         yield worker.stop()
 
-        self.flushLoggedErrors()
+        self.assertEqual(self.flushLoggedErrors(), [])
         self.assertEqual(stops.value, 0)
 
         err = Exception()

--- a/vumi_http_retry/workers/maintainer/worker.py
+++ b/vumi_http_retry/workers/maintainer/worker.py
@@ -1,3 +1,4 @@
+from twisted.python import log
 from twisted.internet import reactor
 from twisted.internet.protocol import ClientCreator
 from twisted.internet.task import LoopingCall
@@ -84,6 +85,10 @@ class RetryMaintainerWorker(BaseWorker):
 
     def on_error(self, err):
         log.err(err)
+        self.stop_reactor()
+
+    def stop_reactor(self):
+        reactor.stop()
 
     def start(self):
         self.state = 'started'

--- a/vumi_http_retry/workers/sender/tests/test_worker.py
+++ b/vumi_http_retry/workers/sender/tests/test_worker.py
@@ -520,7 +520,7 @@ class TestRetrySenderWorker(TestCase):
         worker = yield self.mk_worker()
         yield worker.stop()
 
-        self.flushLoggedErrors()
+        self.assertEqual(self.flushLoggedErrors(), [])
         self.assertEqual(stops.value, 0)
 
         err = Exception()

--- a/vumi_http_retry/workers/sender/worker.py
+++ b/vumi_http_retry/workers/sender/worker.py
@@ -116,6 +116,9 @@ class RetrySenderWorker(BaseWorker):
 
     def on_error(self, err):
         log.err(err)
+        self.stop_reactor()
+
+    def stop_reactor(self):
         reactor.stop()
 
     def start(self):


### PR DESCRIPTION
We want our services to stop so that the thing managing their processes can restart them.
