### PR TITLE
Use new format for string formatting of service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 install:
   - "pip install -r requirements.txt --use-wheel"

--- a/vumi_http_retry/workers/api/service.py
+++ b/vumi_http_retry/workers/api/service.py
@@ -17,7 +17,8 @@ def makeService(options):
     service = Service.from_options(options)
     site = Site(service.worker.app.resource())
 
-    strports_service = strports.service(str(service.worker.config.port), site)
+    strports_service = strports.service(
+        'tcp:{}'.format(str(service.worker.config.port)), site)
     strports_service.setServiceParent(service)
 
     return service

--- a/vumi_http_retry/workers/sender/worker.py
+++ b/vumi_http_retry/workers/sender/worker.py
@@ -3,6 +3,7 @@ from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from twisted.internet.protocol import ClientCreator
 from twisted.internet.defer import inlineCallbacks, Deferred, succeed
+from twisted.internet.error import ConnectingCancelledError
 from twisted.web._newclient import ResponseNeverReceived
 
 from txredis.client import RedisClient
@@ -106,7 +107,7 @@ class RetrySenderWorker(BaseWorker):
         try:
             resp = yield retry(
                 req, timeout=self.config.timeout, **self.config.overrides)
-        except ResponseNeverReceived:
+        except (ResponseNeverReceived, ConnectingCancelledError):
             yield self.handle_retry_timeout(req)
             return
 


### PR DESCRIPTION
When using string to specify the address of a service, older twisted used to allow just the port, eg. `"80"`.

With newer versions of twisted, the `serverFromString` method is now used, which no longer accepts just a port, eg. `"tcp:80"`.